### PR TITLE
MAINT: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,7 @@ sphinx:
   builder: html
   # fail on warning is false until i get the API doc build sorted out
   fail_on_warning: false
+  configuration: book/conf.py
 
 formats:
   - pdf


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/