### PR TITLE
Start writing better parallel docs

### DIFF
--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -214,17 +214,17 @@ It is important to omit the "strategy=None" seen in the default config. This set
 
 The full docs for the Parsl SlurmProvider may be found [here](https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider). In our documentation, we will break down the ones we have found most necessary.
 
-*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* Slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by Slurm.
+*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* Slurm jobs, but it is not guaranteed they will all actually run. When/how they get scheduled is determined by Slurm.
 
 *nodes_per_block:* How many compute nodes to request per Slurm job submitted.
 
 *cores_per_node:* The amount of CPU cores to request per compute node.
 
-*mem_per_node:* The amount of memory to request per compute node.
+*mem_per_node:* The amount of memory to request per compute node in gigabytes.
 
-*walltime:* The max time for the Slurm jobs submitted. Each block represents a Parsl job.
+*walltime:* The max time for the Slurm jobs submitted. Each block represents a Parsl job in "HH:MM:SS" format.
 
-*exclusive:* Whether to request nodes that are free from other running jobs or not.
+*exclusive:* Whether to request nodes that are free from other running jobs or not (Slurm will make sure we have access to the resources we asked for regardless of whether there are other jobs on the node).
 
 *worker_init:* Bash commands to run on the worker jobs submitted by Parsl. You will most likely need to activate your QIIME 2 conda environment here.
 

--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -44,12 +44,12 @@ This configuration defines two `Executors`.
 2. The [`HighThroughputExecutor`](https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.HighThroughputExecutor.html?highlight=HighThroughputExecutor) that parallelizes jobs across multiple processes.
 
 In this case, the `HighThroughputExecutor` is designated as the default by nature of it's `label` value being `default`.
-Your parsl configuration **must** define an executor with the label `default`, and this is the executor that QIIME 2 will use to dispatch your jobs to if you do not specify an alternative.
+Your Parsl configuration **must** define an executor with the label `default`, and this is the executor that QIIME 2 will use to dispatch your jobs to if you do not specify an alternative.
 
 ````{admonition} The parsl.Config object
 :class: tip
 
-This parsl configuration is ultimately read into a `parsl.Config` object internally in QIIME 2.
+This Parsl configuration is ultimately read into a `parsl.Config` object internally in QIIME 2.
 The `parsl.Config` object that corresponds to the above example would look like the following:
 
 ```python
@@ -72,7 +72,7 @@ config = parsl.Config(
 
 ### Parsl configuration, line-by-line
 
-This first line of [the default configuration file presented above](default-parsl-configuration-file) indicates that this is the parsl section (or [table](https://toml.io/en/v1.0.0#table), to use TOML's terminology) of our configuration file.
+This first line of [the default configuration file presented above](default-parsl-configuration-file) indicates that this is the Parsl section (or [table](https://toml.io/en/v1.0.0#table), to use TOML's terminology) of our configuration file.
 
 ```
 [parsl]
@@ -97,7 +97,7 @@ max_threads = 7
 ```
 
 The double square brackets (`[[ ... ]]`) indicates that [this is an array](https://toml.io/en/v1.0.0#array-of-tables), `executors`, that is nested under the `parsl` table.
-`class` indicates the specific parsl class that is being configured ([`parsl.executors.ThreadPoolExecutor`](https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.ThreadPoolExecutor.html#parsl.executors.ThreadPoolExecutor) in this case); `label` provides a label that you can use to refer to this executor elsewhere; and `max_threads` is a configuration value for the ThreadPoolExecutor class which corresponds to a parameter name for the class's constructor.
+`class` indicates the specific Parsl class that is being configured ([`parsl.executors.ThreadPoolExecutor`](https://parsl.readthedocs.io/en/stable/stubs/parsl.executors.ThreadPoolExecutor.html#parsl.executors.ThreadPoolExecutor) in this case); `label` provides a label that you can use to refer to this executor elsewhere; and `max_threads` is a configuration value for the ThreadPoolExecutor class which corresponds to a parameter name for the class's constructor.
 In this example a value of 7 is specified for `max_threads`, but as noted above this will be computed specifically for your machine when this file is created.
 
 Parsl's `ThreadPoolExecutor` runs on a single node, so we provide a second executor which can utilize up to 2000 nodes.
@@ -119,11 +119,11 @@ In this case, we use [`parsl.providers.LocalProvider`](https://parsl.readthedocs
 
 ### The run_dir parameter
 
-Another parameter to the config that we do not set but that you should definitely be aware of is `run_dir`. This indicates the directory that parsl will write logging info to and it defaults to `./runinfo`. This means that if you run a QIIME 2 pipleine in parallel without this parameter set a runinfo directory will be created inside the directory you ran the action in.
+Another parameter to the config that we do not set but that you should definitely be aware of is `run_dir`. This indicates the directory that Parsl will write logging info to and it defaults to `./runinfo`. This means that if you run a QIIME 2 pipleine in parallel without this parameter set a runinfo directory will be created inside the directory you ran the action in.
 
 ### Mapping {term}`Actions <action>` to executors
 
-An executor mapping can be added to your parsl configuration that defines which actions should run on which executors.
+An executor mapping can be added to your Parsl configuration that defines which actions should run on which executors.
 If an action is unmapped, it will run on the default executor.
 This can be specified as follows:
 
@@ -160,7 +160,7 @@ When QIIME 2 needs configuration information, the following precedence order is 
 If no configuration is found after checking those four locations, QIIME 2 writes a default configuration file to `$CONDA_PREFIX/etc/qiime2_config.toml` and uses that.
 This implies that after your first time running QIIME 2 in parallel without a config in at least one of the first 3 locations, the path referenced in step 4 will exist and contain a configuration file.
 
-Alternatively, when using {term}`q2cli`, you can provide a specific configuration for use in configuring parsl using the `--parallel-config` option.
+Alternatively, when using {term}`q2cli`, you can provide a specific configuration for use in configuring Parsl using the `--parallel-config` option.
 If provided, this overrides the priority order above.
 
 Similarly, when using the {term}`Python 3 API`, you can provide a specific configuration by passing a `parsl.Config` object into your `ParallelConfig` context manager.
@@ -186,7 +186,7 @@ python -c "import appdirs; print(appdirs.site_config_dir('qiime2'))"
 ```
 ````
 
-### Configuring parsl for HPC
+### Configuring Parsl for HPC
 
 Parsl supports a large number of compute environments via its [providers](https://parsl.readthedocs.io/en/stable/reference.html#providers). The HPC clusters used by the QIIME 2 core dev team use [Slurm](https://slurm.schedmd.com/documentation.html). As such, we will give an example here of configuring a QIIME 2 action to run in parallel on a Slurm based HPC cluster using Parsl's SlurmProvider.
 
@@ -209,12 +209,12 @@ Note we are still using a HighThroughputExecutor but with a different provider. 
 
 ````{admonition} Omit "strategy=None"
 :class: note
-It is important to omit the "strategy=None" seen in the default config. This setting will prevent parsl from properly parallelizing in an HPC environment.
+It is important to omit the "strategy=None" seen in the default config. This setting will prevent Parsl from properly parallelizing in an HPC environment.
 ````
 
 #### SlurmProvider Args
 
-*max_blocks:* The maximum number of blocks (parsl jobs) to maintain. Parsl will submit *max_blocks* slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by slurm.
+*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by slurm.
 
 *nodes_per_block:* How many compute nodes to request per slurm job submitted.
 
@@ -222,11 +222,11 @@ It is important to omit the "strategy=None" seen in the default config. This set
 
 *mem_per_node:* The amount of memory to request per compute node.
 
-*walltime:* The max time for the slurm jobs submitted. Each block represents a parsl job.
+*walltime:* The max time for the slurm jobs submitted. Each block represents a Parsl job.
 
 *exclusive:* Whether to request nodes that are free from other running jobs or not.
 
-*worker_init:* Bash commands to run on the worker jobs submitted by parsl. You will most likely need to activate your QIIME 2 conda environment here.
+*worker_init:* Bash commands to run on the worker jobs submitted by Parsl. You will most likely need to activate your QIIME 2 conda environment here.
 
 #### Example slurm config
 
@@ -306,7 +306,7 @@ qiime moshpit classify-kraken2 \
         --verbose
 ```
 
-`classify-kraken2` is a pipeline that was written specifically to take advantage of QIIME 2's parallel capabilities. It requires a significant amount of compute resources to match a large number of sequences against a very large kraken database hence the large amount of RAM requested in the parsl config, and the need to run in parallel in the first place.
+`classify-kraken2` is a pipeline that was written specifically to take advantage of QIIME 2's parallel capabilities. It requires a significant amount of compute resources to match a large number of sequences against a very large kraken database hence the large amount of RAM requested in the Parsl config, and the need to run in parallel in the first place.
 
 It will split the input sequences into `--p-num-partitions` (defaults to splitting each sample into its own partition) sets and then classify them in parallel. The 10 partitions here corresponds to our 10 blocks. We will have 10 different sets of sequences each of which can be submitted to its own block. The 20 threads here corresponds to our 20 cores_per_worker. This allows us to classify `num_blocks * workers_per_block * cores_per_worker` or `10 * 1 * 20 = 200` sequences at a time!
 

--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -212,7 +212,9 @@ Note we are still using a HighThroughputExecutor but with a different provider. 
 It is important to omit the "strategy=None" seen in the default config. This setting will prevent Parsl from properly parallelizing in an HPC environment.
 ````
 
-#### SlurmProvider Args
+#### SlurmProvider parameters
+
+The full docs for the Parsl SlurmProvider may be found [here](https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider). In our documentation, we will break down the ones we have found most necessary.
 
 *max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by slurm.
 
@@ -252,7 +254,7 @@ exclusive = false
 worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;"
 ```
 
-*max_blocks = 10:* We will run up to 5 slurm jobs.
+*max_blocks = 10:* We will run up to 10 slurm jobs.
 
 *nodes_per_block = 1:* Each job will use one compute node.
 

--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -128,14 +128,12 @@ If an action is unmapped, it will run on the default executor.
 This can be specified as follows:
 
 ```
-[parsl.executor_mapping]
+[parsl.executor_mapping.plugin_name]
 action_name = "tpool"
-```
+other_action_name = "tpool"
 
-```{warning}
-The mechanism for specifying action names at present does not handle the case of different plugins defining actions with the same name.
-This mechanism will likely change soon, and may be a {term}`breaking change`.
-You can track progress on this [here](https://github.com/qiime2/qiime2/issues/802).
+[parsl.executor_mapping.other_plugin_name]
+action_name = "tpool"
 ```
 
 (view-parsl-configuration)=

--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -216,21 +216,21 @@ It is important to omit the "strategy=None" seen in the default config. This set
 
 The full docs for the Parsl SlurmProvider may be found [here](https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider). In our documentation, we will break down the ones we have found most necessary.
 
-*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by slurm.
+*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* Slurm jobs, but it is not guarantees they will all actually run. When/how they get scheduled is determined by Slurm.
 
-*nodes_per_block:* How many compute nodes to request per slurm job submitted.
+*nodes_per_block:* How many compute nodes to request per Slurm job submitted.
 
 *cores_per_node:* The amount of CPU cores to request per compute node.
 
 *mem_per_node:* The amount of memory to request per compute node.
 
-*walltime:* The max time for the slurm jobs submitted. Each block represents a Parsl job.
+*walltime:* The max time for the Slurm jobs submitted. Each block represents a Parsl job.
 
 *exclusive:* Whether to request nodes that are free from other running jobs or not.
 
 *worker_init:* Bash commands to run on the worker jobs submitted by Parsl. You will most likely need to activate your QIIME 2 conda environment here.
 
-#### Example slurm config
+#### Example Slurm config
 
 This is an example of a config we have actually used to run analyses on our HPC cluster. Let's break down what these parameters mean.
 
@@ -254,7 +254,7 @@ exclusive = false
 worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;"
 ```
 
-*max_blocks = 10:* We will run up to 10 slurm jobs.
+*max_blocks = 10:* We will run up to 10 Slurm jobs.
 
 *nodes_per_block = 1:* Each job will use one compute node.
 
@@ -262,7 +262,7 @@ worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;"
 
 *mem_per_node = 100:* 100GB of RAM will be used per compute node.
 
-*walltime = "10:00:00":* Each slurm job (block) will run for up to 10 hours.
+*walltime = "10:00:00":* Each Slurm job (block) will run for up to 10 hours.
 
 *exclusive = false:* We don't care if there are other jobs running on the nodes we use.
 
@@ -274,11 +274,11 @@ And finally, let's take a look at those parameters given to the HighThroughputEx
 
 *max_workers_per_node = 1:* Each compute node will only have one worker and only be able to handle one job at a time.
 
-This config will queue 10 slurm jobs that will run for up to 10 hours each. Each job will use 20 cores and 100GB of RAM on one compute node. Due to the `max_workers_per_node = 1`, each of these slurm jobs with these resources will be able to handle 1 QIIME 2 action at a time.
+This config will queue 10 Slurm jobs that will run for up to 10 hours each. Each job will use 20 cores and 100GB of RAM on one compute node. Due to the `max_workers_per_node = 1`, each of these Slurm jobs with these resources will be able to handle 1 QIIME 2 action at a time.
 
-### Example slurm job
+### Example Slurm job
 
-This is the slurm job we submitted that used the above config. We call this job we actually submit directly the "pilot job." This job will itself submit the worker jobs that actually do the work,
+This is the Slurm job we submitted that used the above config. We call this job we actually submit directly the "pilot job." This job will itself submit the worker jobs that actually do the work,
 
 ```bash
 #!/bin/bash

--- a/book/references/parallel-configuration.md
+++ b/book/references/parallel-configuration.md
@@ -119,7 +119,9 @@ In this case, we use [`parsl.providers.LocalProvider`](https://parsl.readthedocs
 
 ### The run_dir parameter
 
-Another parameter to the config that we do not set but that you should definitely be aware of is `run_dir`. This indicates the directory that Parsl will write logging info to and it defaults to `./runinfo`. This means that if you run a QIIME 2 pipleine in parallel without this parameter set a runinfo directory will be created inside the directory you ran the action in.
+Another parameter to the config that we do not set but that you should definitely be aware of is `run_dir`. 
+This indicates the directory that Parsl will write logging info to and it defaults to `./runinfo`. 
+This means that if you run a QIIME 2 Pipeline in parallel without this parameter set, a `runinfo` directory will be created inside the directory that you ran the action from.
 
 ### Mapping {term}`Actions <action>` to executors
 
@@ -186,7 +188,9 @@ python -c "import appdirs; print(appdirs.site_config_dir('qiime2'))"
 
 ### Configuring Parsl for HPC
 
-Parsl supports a large number of compute environments via its [providers](https://parsl.readthedocs.io/en/stable/reference.html#providers). The HPC clusters used by the QIIME 2 core dev team use [Slurm](https://slurm.schedmd.com/documentation.html). As such, we will give an example here of configuring a QIIME 2 action to run in parallel on a Slurm based HPC cluster using Parsl's SlurmProvider.
+Parsl supports a large number of compute environments via its [providers](https://parsl.readthedocs.io/en/stable/reference.html#providers).
+The HPC cluster used by the QIIME 2 Framework development team, for example, uses [Slurm](https://slurm.schedmd.com/documentation.html).
+As such, we will give an example here of configuring a QIIME 2 action to run in parallel on a Slurm based HPC cluster using Parsl's SlurmProvider.
 
 This is what a QIIME 2 config for running on Slurm looks like at a high level.
 
@@ -203,30 +207,39 @@ class = "SlurmProvider"
 ...
 ```
 
-Note we are still using a HighThroughputExecutor but with a different provider. In the default config, we were using the LocalProvider which doesn't take any real configuration to start using. In this case we are using the SlurmProvider which requires a lot more configuration. Let's break down how to configure the SlurmProvider.
+Note we are still using a HighThroughputExecutor but with a different provider. 
+In the default config, we were using the LocalProvider which doesn't take any real configuration to start using.
+In this case we are using the SlurmProvider which requires a lot more configuration.
+Let's break down how to configure the SlurmProvider.
 
 ````{admonition} Omit "strategy=None"
 :class: note
-It is important to omit the "strategy=None" seen in the default config. This setting will prevent Parsl from properly parallelizing in an HPC environment.
+It is important to omit the "strategy=None" seen in the default config.
+This setting will prevent Parsl from properly parallelizing in an HPC environment.
 ````
 
 #### SlurmProvider parameters
 
-The full docs for the Parsl SlurmProvider may be found [here](https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider). In our documentation, we will break down the ones we have found most necessary.
+The full docs for the Parsl SlurmProvider may be found [here](https://parsl.readthedocs.io/en/stable/stubs/parsl.providers.SlurmProvider.html#parsl.providers.SlurmProvider).
+In our documentation, we will break down the ones we have found most necessary.
 
-*max_blocks:* The maximum number of blocks (Parsl jobs) to maintain. Parsl will submit *max_blocks* Slurm jobs, but it is not guaranteed they will all actually run. When/how they get scheduled is determined by Slurm.
+`max_blocks`: The maximum number of blocks (Parsl jobs) to maintain.
+ Parsl will submit *max_blocks* Slurm jobs, but it is not guaranteed they will all actually run. 
+ When and how they get scheduled is determined by Slurm.
 
-*nodes_per_block:* How many compute nodes to request per Slurm job submitted.
+`nodes_per_block`: How many compute nodes to request per Slurm job submitted.
 
-*cores_per_node:* The amount of CPU cores to request per compute node.
+`cores_per_node:` The number of CPU cores to request per compute node.
 
-*mem_per_node:* The amount of memory to request per compute node in gigabytes.
+`mem_per_node`: The amount of memory to request per compute node in gigabytes.
 
-*walltime:* The max time for the Slurm jobs submitted. Each block represents a Parsl job in "HH:MM:SS" format.
+`walltime`: The max time for the Slurm jobs submitted.
+ Each block represents a Parsl job in "HH:MM:SS" format.
 
-*exclusive:* Whether to request nodes that are free from other running jobs or not (Slurm will make sure we have access to the resources we asked for regardless of whether there are other jobs on the node).
+`exclusive`: Whether to request nodes that are free from other running jobs or not (Slurm will make sure we have access to the resources we asked for regardless of whether there are other jobs on the node).
 
-*worker_init:* Bash commands to run on the worker jobs submitted by Parsl. You will most likely need to activate your QIIME 2 conda environment here.
+`worker_init`: Bash commands to run on the worker jobs submitted by Parsl.
+ You may need to activate your QIIME 2 conda environment here.
 
 #### Example Slurm config
 
@@ -252,31 +265,35 @@ exclusive = false
 worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;"
 ```
 
-*max_blocks = 10:* We will run up to 10 Slurm jobs.
+`max_blocks = 10`: We will run up to 10 Slurm jobs.
 
-*nodes_per_block = 1:* Each job will use one compute node.
+`nodes_per_block = 1`: Each job will use one compute node.
 
-*cores_per_node = 20:* 20 cores will be used per compute node.
+`cores_per_node = 20`: 20 cores will be used per compute node.
 
-*mem_per_node = 100:* 100GB of RAM will be used per compute node.
+`mem_per_node = 100`: 100GB of RAM will be used per compute node.
 
-*walltime = "10:00:00":* Each Slurm job (block) will run for up to 10 hours.
+`walltime = "10:00:00"`: Each Slurm job (block) will run for up to 10 hours.
 
-*exclusive = false:* We don't care if there are other jobs running on the nodes we use.
+`exclusive = false`: We don't care if there are other jobs running on the nodes we use.
 
-*worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;":* Activate the necessary QIIME 2 conda environment for each worker job.
+`worker_init = "module load anaconda3; conda activate qiime2-shotgun-dev;"`: Activate the necessary QIIME 2 conda environment for each worker job.
 
 And finally, let's take a look at those parameters given to the HighThroughputExecutor.
 
-*cores_per_worker = 20:* Each worker will have access to 20 cores. This was set to match `cores_per_node / max_workers_per_node` just to ensure all our resources are set to be available.
+`cores_per_worker = 20`: Each worker will have access to 20 cores.
+ This was set to match `cores_per_node / max_workers_per_node`, just to ensure all our resources are set to be available.
 
-*max_workers_per_node = 1:* Each compute node will only have one worker and only be able to handle one job at a time.
+`max_workers_per_node = 1`: Each compute node will only have one worker and only be able to handle one job at a time.
 
-This config will queue 10 Slurm jobs that will run for up to 10 hours each. Each job will use 20 cores and 100GB of RAM on one compute node. Due to the `max_workers_per_node = 1`, each of these Slurm jobs with these resources will be able to handle 1 QIIME 2 action at a time.
+This config will queue 10 Slurm jobs that will run for up to 10 hours each. Each job will use 20 cores and 100GB of RAM on one compute node.
+Due to the `max_workers_per_node = 1`, each of these Slurm jobs with these resources will be able to handle one QIIME 2 action at a time.
 
 ### Example Slurm job
 
-This is the Slurm job we submitted that used the above config. We call this job we actually submit directly the "pilot job." This job will itself submit the worker jobs that actually do the work,
+This is the Slurm job we submitted that used the above config.
+We call this job that we actually submit directly the "pilot job."
+This job will itself submit the "worker jobs," which are the ones that will actually do the work,
 
 ```bash
 #!/bin/bash
@@ -306,15 +323,26 @@ qiime moshpit classify-kraken2 \
         --verbose
 ```
 
-`classify-kraken2` is a pipeline that was written specifically to take advantage of QIIME 2's parallel capabilities. It requires a significant amount of compute resources to match a large number of sequences against a very large kraken database hence the large amount of RAM requested in the Parsl config, and the need to run in parallel in the first place.
+`classify-kraken2` is a pipeline that was written specifically to take advantage of QIIME 2's parallel capabilities.
+It requires a significant amount of compute resources to match a large number of sequences against a very large kraken database hence the large amount of RAM requested in the Parsl config, and the need to run in parallel in the first place.
 
-It will split the input sequences into `--p-num-partitions` (defaults to splitting each sample into its own partition) sets and then classify them in parallel. The 10 partitions here corresponds to our 10 blocks. We will have 10 different sets of sequences each of which can be submitted to its own block. The 20 threads here corresponds to our 20 cores_per_worker. This allows us to classify `num_blocks * workers_per_block * cores_per_worker` or `10 * 1 * 20 = 200` sequences at a time!
+It will split the input sequences into `--p-num-partitions` (defaults to splitting each sample into its own partition) sets and then classify them in parallel.
+The 10 partitions here corresponds to our 10 blocks.
+We will have 10 different sets of sequences each of which can be submitted to its own block.
+The 20 threads here corresponds to our 20 `cores_per_worker`. 
+This allows us to classify `num_blocks * workers_per_block * cores_per_worker` or `10 * 1 * 20 = 200` sequences at a time.
 
-We make sure to set our TMPDIR and the [Artifact Cache](artifact-cache-tutorial) we are using for this action to a location that is accessible globally on the HPC we are using. It is important that you do this to make sure your actions which will be spread across compute nodes are wrtiting information that needs to be shared amongst them to a location they can all see.
+We make sure to set our `TMPDIR` and the [Artifact Cache](artifact-cache-tutorial) we are using for this action to a location that is accessible globally on the HPC we are using.
+It is important that you do this to make sure your actions which will be spread across compute nodes are writing information that needs to be shared amongst them to a location they can all see.
 
-This job has a walltime of 24 hours which is significantly longer than the jobs we will be submitting. This is because it can take some time after your pilot job starts running for your worker jobs to actually start running. This job also only asks for 8GB of RAM. This is because this job doesn't do any of the actual computation, so it doesn't require a large amount of compute resources.
+This job has a walltime of 24 hours which is significantly longer than the jobs we will be submitting.
+This is because it can take some time after your pilot job starts running for your worker jobs to actually start running.
+This job also only asks for 8GB of RAM.
+This is because this job doesn't do any of the actual computation, so it doesn't require a large amount of compute resources.
 
 ````{admonition} We understand this can be difficult!
 :class: note
-We understand that figuring out how to set up your parallel config for a given action can be difficult. It requires you to understand not only your data and the action you are trying to run but also your compute system. If you need help with this do not hesitate to post on [the QIIME 2 forum](https://forum.qiime2.org).
+We understand that figuring out how to set up your parallel config for a given action can be difficult.
+It requires you to understand not only your data and the action you are trying to run but also your compute system.
+If you need help with this do not hesitate to post on [the QIIME 2 forum](https://forum.qiime2.org).
 ````

--- a/book/tutorials/parallel-pipeline.md
+++ b/book/tutorials/parallel-pipeline.md
@@ -117,7 +117,7 @@ with ParallelConfig(parallel_config=c, action_executor_mapping=m):
 
 ## Parsl configuration
 
-To learn how to configure parsl for your own usage, refer to [](parallel-configuration).
+To learn how to configure Parsl for your own usage, refer to [](parallel-configuration).
 
 [^formal-informal-parallel]: QIIME 2 {term}`Actions <Action>` can provide formal (i.e., Parsl-based) or informal (e.g., multi-threaded execution of a third party program) parallel computing support.
  To learn more about the distinction, see [](types-of-parallel-support).


### PR DESCRIPTION
Begin adding parallel docs that better describe how to set up a parallel config by further discussing some of the commonly used arguments to the config and sharing some of what has worked for us.